### PR TITLE
Improve config handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .dub
 bin
+config.yml
 config.yaml
 public/assets/avatars/*
 !public/assets/avatars/.gitkeep

--- a/source/pastemyst/data/config.d
+++ b/source/pastemyst/data/config.d
@@ -52,7 +52,7 @@ public struct Github
      + github client id
      +/
     public string id;
-    
+
     /++
      + github client secret
      +/
@@ -68,7 +68,7 @@ public struct Gitlab
      + gitlab client id
      +/
     public string id;
-    
+
     /++
      + gitlab client secret
      +/
@@ -83,8 +83,6 @@ public struct Gitlab
 public Config config() { return _config; }
 private Config _config;
 
-private const string configPath = "config.yaml";
-
 static this()
 {
     version (unittest)
@@ -95,60 +93,67 @@ static this()
     {
         import std.file : exists;
         import std.exception : enforce;
+        import std.format : format;
 
-        if (!exists("config.yaml"))
+        // default configuration file
+        string configName = "config.yaml";
+
+        if(!exists(configName))
         {
-            throw new Exception("missing config.yaml");
+            // if doesn't exists, fallback to .yml
+            configName = "config.yml";
+            enforce(exists(configName), format!"missing %s"(configName));
         }
 
         Node cfg;
 
         try
         {
-            cfg = Loader.fromFile("config.yaml").load();
+            cfg = Loader.fromFile(configName).load();
         }
         catch (YAMLException e)
         {
-            throw new Exception("config.yaml: invalid or empty");
+        	e.msg = format!"%s: invalid or empty"(configName);
+        	throw e;
         }
 
         // TODO: clean this up
 
-        enforce(cfg.isValid(), "config.yaml: invalid");
+        enforce(cfg.isValid(), format!"%s: invalid"(configName));
 
-        enforce(cfg.containsKey("github"), "config.yaml: missing github");
+        enforce(cfg.containsKey("github"), format!"%s: missing github"(configName));
 
-        enforce(cfg["github"].containsKey("id"), "config.yaml: missing github id");
-        enforce(cfg["github"].containsKey("secret"), "config.yaml: missing github secret");
+        enforce(cfg["github"].containsKey("id"), format!"%s: missing github id"(configName));
+        enforce(cfg["github"].containsKey("secret"), format!"%s: missing github secret"(configName));
 
         _config.github.id = cfg["github"]["id"].as!string();
         _config.github.secret = cfg["github"]["secret"].as!string();
 
-        enforce(cfg.containsKey("gitlab"), "config.yaml: missing gitlab");
+        enforce(cfg.containsKey("gitlab"), format!"%s: missing gitlab"(configName));
 
-        enforce(cfg["gitlab"].containsKey("id"), "config.yaml: missing gitlab id");
-        enforce(cfg["gitlab"].containsKey("secret"), "config.yaml: missing gitlab secret");
+        enforce(cfg["gitlab"].containsKey("id"), format!"%s: missing gitlab id"(configName));
+        enforce(cfg["gitlab"].containsKey("secret"), format!"%s: missing gitlab secret"(configName));
 
         _config.gitlab.id = cfg["gitlab"]["id"].as!string();
         _config.gitlab.secret = cfg["gitlab"]["secret"].as!string();
 
-        enforce(cfg.containsKey("hostname"), "config.yaml: missing hostname");
+        enforce(cfg.containsKey("hostname"), format!"%s: missing hostname"(configName));
 
         _config.hostname = cfg["hostname"].as!string();
 
-        enforce(cfg.containsKey("development_instance"), "config.yaml: missing development_instance");
+        enforce(cfg.containsKey("development_instance"), format!"%s: missing development_instance"(configName));
 
         _config.devInstance = cfg["development_instance"].as!bool();
 
-        enforce(cfg.containsKey("host_ip"), "config.yaml: missing host_ip");
+        enforce(cfg.containsKey("host_ip"), format!"%s: missing host_ip"(configName));
 
         _config.hostIp = cfg["host_ip"].as!string();
 
-        enforce(cfg.containsKey("host_port"), "config.yaml: missing host_port");
+        enforce(cfg.containsKey("host_port"), format!"%s: missing host_port"(configName));
 
         _config.hostPort = cfg["host_port"].as!ushort();
 
-        enforce(cfg.containsKey("mongo_connection"), "config.yaml: missing mongo_connection");
+        enforce(cfg.containsKey("mongo_connection"), format!"%s: missing mongo_connection"(configName));
 
         _config.mongoConnection = cfg["mongo_connection"].as!string();
     }


### PR DESCRIPTION
This PR will make possible the usage of `config.yaml` and fallback to `config.yml` if no `.yaml` found as `.yml` should also be a valid extension.

Happy Hacktoberfest!