### PR TITLE
Fix/diff temp dir usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM dlang2/dmd-ubuntu:2.093.1
 COPY --from=build /usr/bin/pastemyst-autodetect /usr/bin/
 
 RUN apt-get update && \
-    apt-get install -y libssl-dev libscrypt-dev
+    apt-get install -y libssl-dev libscrypt-dev patch
 
 WORKDIR /app
 


### PR DESCRIPTION
```md
Changes:
 * now every file and directory is deleted after exiting the scope
 * changed pipe usage to `pipeProcess`
 * paths are generated with `buildPath`
 * every temp file/dir is created at `tempDir`
 * every file/dir name has an unique id
 * removed casts
 * `diff` now throws a DiffException if it's exit code is `2`
 * all around clean up
```